### PR TITLE
SEARCH-9753: build and push image to ECR

### DIFF
--- a/ci/cribl/jenkins/Jenkinsfile
+++ b/ci/cribl/jenkins/Jenkinsfile
@@ -40,12 +40,28 @@ pipeline {
     }
 
     stage('Deploy') {
-      steps {
-        script {
-          withCredentials([string(credentialsId: 'STAGING_BUCKET', variable: 'S3_BUCKET')]) {
-            sh "ci/cribl/scripts/deploy.sh"
+      parallel {
+
+        stage('Copy Binary to S3') {
+          steps {
+            script {
+              withCredentials([string(credentialsId: 'STAGING_BUCKET', variable: 'S3_BUCKET')]) {
+                sh "ci/cribl/scripts/deploy.sh"
+              }
+            }
           }
         }
+
+        stage('Build & Push Container Images') {
+          steps {
+            script {
+              withCredentials([string(credentialsId: 'SAAS_OPS_ACCOUNT', variable: 'SAAS_OPS_ACCOUNT')]) {
+                sh "ci/cribl/scripts/build-and-deploy-container-image.sh ${BUILD_DIR}/programs/clickhouse"
+              }
+            }
+          }
+        }
+
       }
     }
   }

--- a/ci/cribl/jenkins/podspec.yml
+++ b/ci/cribl/jenkins/podspec.yml
@@ -19,15 +19,22 @@ spec:
       args:
         - 99d
       env:
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+      resources:
+        requests:
+          memory: "55Gi"
+          cpu: "31000m"
+    - name: dind-daemon
+      image: docker:23.0.5-dind
+      securityContext:
+        privileged: true
+      env:
         - name: DOCKER_TLS_CERTDIR
           value: ''
       volumeMounts:
         - name: docker-graph-storage
           mountPath: /var/lib/docker
-      resources:
-        requests:
-          memory: "55Gi"
-          cpu: "31000m"
   imagePullSecrets:
   - name: regcred
   terminationGracePeriodSeconds: 0

--- a/ci/cribl/scripts/build-and-deploy-container-image.sh
+++ b/ci/cribl/scripts/build-and-deploy-container-image.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -ex
+
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+DOCKER_BUILD_DIR=$(realpath ${THIS_DIR}/../../docker/clickhouse-server)
+DOCKER_BUILD_FILE="${DOCKER_BUILD_DIR}/from_cribl/Dockerfile"
+
+if [ $# -ne 1 ]; then
+  >&2 echo "usage: $0 <absolute path to ClickHouse binary>"
+  exit 1
+elif [ ! -e "${1}" ]; then
+  >&2 echo "'${1}' does not exist!"
+  exit 1
+fi
+
+# Copy the binary to the docker build dir
+cp ${1} ${DOCKER_BUILD_DIR}/
+
+REGION="us-west-2"
+ECR_REPO="${SAAS_OPS_ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/cribl-cloud/clickhouse-server"
+BASE_IMAGE_REPO="${SAAS_OPS_ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/cribl-cloud/ubuntu-base"
+# TODO: Replace the commit with a semver once that's added
+VERSION_TAG="$(git rev-parse HEAD)"
+
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_REGISTRY_NAME || exit 1
+docker build --build-arg IMAGE_REPO=${BASE_IMAGE_REPO} -t ${ECR_REPO}:${VERSION_TAG} --push -f ${DOCKER_BUILD_FILE} ${DOCKER_BUILD_DIR}

--- a/ci/cribl/scripts/build-and-deploy-container-image.sh
+++ b/ci/cribl/scripts/build-and-deploy-container-image.sh
@@ -17,10 +17,11 @@ fi
 cp ${1} ${DOCKER_BUILD_DIR}/
 
 REGION="us-west-2"
-ECR_REPO="${SAAS_OPS_ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/cribl-cloud/clickhouse-server"
+ECR_REG="${SAAS_OPS_ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com"
+ECR_REPO="${ECR_REG}/cribl-cloud/clickhouse-server"
 BASE_IMAGE_REPO="${SAAS_OPS_ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/cribl-cloud/ubuntu-base"
 # TODO: Replace the commit with a semver once that's added
 VERSION_TAG="$(git rev-parse HEAD)"
 
-aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_REGISTRY_NAME || exit 1
+aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ECR_REG} || exit 1
 docker build --build-arg IMAGE_REPO=${BASE_IMAGE_REPO} -t ${ECR_REPO}:${VERSION_TAG} --push -f ${DOCKER_BUILD_FILE} ${DOCKER_BUILD_DIR}

--- a/ci/cribl/scripts/build.sh
+++ b/ci/cribl/scripts/build.sh
@@ -4,4 +4,4 @@ set -ex
 CORES=$(nproc)
 
 cmake -S . -B ${BUILD_DIR} -DNO_ARMV81_OR_HIGHER=1 -DCMAKE_BUILD_TYPE=Release -DPARALLEL_LINK_JOBS=${CORES}
-(cd build && ninja -j ${CORES} clickhouse-server clickhouse-client)
+(cd build && ninja -j ${CORES} clickhouse)

--- a/ci/cribl/scripts/setup.sh
+++ b/ci/cribl/scripts/setup.sh
@@ -15,6 +15,6 @@ unzip awscliv2.zip
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 echo "deb [arch=$(get_arch) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" >> /etc/apt/sources.list.d/docker.list
-apt update && apt install -y docker-ce-cli
+apt-get update && apt-get install -y docker-ce-cli
 
 git submodule update --init -j $(nproc)

--- a/ci/cribl/scripts/setup.sh
+++ b/ci/cribl/scripts/setup.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 set -ex
 
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+source ${THIS_DIR}/utils.sh
+
 git config --global --add safe.directory ${WORKSPACE}
 
 # need the AWS CLI to make things easier..
 curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install
+
+# install and setup docker CLI
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(get_arch) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" >> /etc/apt/sources.list.d/docker.list
+apt update && apt install -y docker-ce-cli
 
 git submodule update --init -j $(nproc)

--- a/ci/cribl/scripts/utils.sh
+++ b/ci/cribl/scripts/utils.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Echos the given architecture string normalized if it's supported, otherwise nothing
+#   ARCH=$(fix_arch X86_64) # "x64"
+function fix_arch {
+    ARCH=$(echo $1 | tr '[:upper:]' '[:lower:]')
+    case $ARCH in
+      x86_64|x86|x64)    echo 'x64';;
+      arm|arm64|aarch64) echo 'arm64';;
+      universal)         echo 'universal';;
+      *) >&2 "Unsupported architecture; \"$1\"";;
+    esac
+}
+
+# Echos the local architecture if it's supported, otherwise nothing
+#   ARCH=$(get_arch)
+function get_arch {
+    echo $(fix_arch $(uname -m) 2>/dev/null)
+}

--- a/ci/docker/clickhouse-server/from_cribl/Dockerfile
+++ b/ci/docker/clickhouse-server/from_cribl/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+# Use the internal Cribl base image
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}:22.04
 
 # see https://github.com/moby/moby/issues/4032#issuecomment-192327844
 # It could be removed after we move on a version 23:04+

--- a/ci/docker/clickhouse-server/from_cribl/Dockerfile
+++ b/ci/docker/clickhouse-server/from_cribl/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:22.04
+
+# see https://github.com/moby/moby/issues/4032#issuecomment-192327844
+# It could be removed after we move on a version 23:04+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ARG for quick switch to a given ubuntu mirror
+ARG apt_archive="http://archive.ubuntu.com"
+
+# We shouldn't use `apt upgrade` to not change the upstream image. It's updated biweekly
+
+# user/group precreated explicitly with fixed uid/gid on purpose.
+# It is especially important for rootless containers: in that case entrypoint
+# can't do chown and owners of mounted volumes should be configured externally.
+# We do that in advance at the begining of Dockerfile before any packages will be
+# installed to prevent picking those uid / gid by some unrelated software.
+# The same uid / gid (101) is used both for alpine and ubuntu.
+RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+    && groupadd -r clickhouse --gid=101 \
+    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        locales \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
+COPY ./clickhouse /tmp/clickhouse
+RUN ls -l /tmp/clickhouse
+RUN chmod +x /tmp/clickhouse \
+    && /tmp/clickhouse install --user "clickhouse" --group "clickhouse" \
+    && rm -rf /tmp/*
+
+# post install
+# we need to allow "others" access to clickhouse folder, because docker container
+# can be started with arbitrary uid (openshift usecase)
+RUN clickhouse-local -q 'SELECT * FROM system.build_options' \
+    && mkdir -p /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client \
+    && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV TZ UTC
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+COPY docker_related_config.xml /etc/clickhouse-server/config.d/
+COPY entrypoint.sh /entrypoint.sh
+
+EXPOSE 9000 8123 9009
+VOLUME /var/lib/clickhouse
+
+ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
**Changes:**

- Build and push the container image to our private ECR
- - Image is built in the same way as how ClickHouse does it, but using our internal cloud specific base image of ubuntu
- Updated podspec to support docker in docker (DinD)
- `ninja` build target changed, so had to update it

Tested in the pipeline job and was able to build and push to ECR; pulled the image from ECR and was able to start the container and it appears the server started fine and the client was able to connect.